### PR TITLE
Document how to add custom logo to the top bar

### DIFF
--- a/content/docs/theme-options/styling.md
+++ b/content/docs/theme-options/styling.md
@@ -5,13 +5,16 @@ icon: palette
 description: "Styling Lotus Docs."
 date: 2023-04-26T01:48:15+00:00
 lastmod: 2023-04-26T01:48:15+00:00
-draft: true
+draft: false
 images: []
 toc: true
 ---
 
-## Theme Colour/Accent
-
-## Google Fonts
-
 ## Assets
+### Custom logo on the top bar
+You can replace the default svg logo in the by adding 2 new files into your own project:
+* `assets/images/logos/logo.svg`
+* `assets/images/logos/mark.svg`
+
+`logo.svg` is used on bigger screen sizes and it can be wider.
+`mark.svg` is used on smaller screen sizes and it should be narrow.


### PR DESCRIPTION
I was testing out the site and figured out how to use custom logos to replace the default blue book.

I thought that this is probably useful for other users as well and added it into the docs.